### PR TITLE
fix: add check for pinned aswcli version

### DIFF
--- a/devin-ai-startup-commands.sh
+++ b/devin-ai-startup-commands.sh
@@ -5,10 +5,27 @@ set -eo pipefail
 pushd ~
 DEBIAN_FRONTEND=noninteractive
 sudo apt update
+
 sudo apt install curl unzip -y
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip -o awscliv2.zip
-sudo ./aws/install --bin-dir /usr/bin --install-dir /usr/local/aws-cli --update
+
+# Check if awscli is already installed with the correct version
+AWSCLI_VERSION="2.33.19"
+if command -v aws &> /dev/null; then
+  INSTALLED_VERSION=$(aws --version 2>&1 | awk '{print $1}' | cut -d'/' -f2)
+  if [ "$INSTALLED_VERSION" = "$AWSCLI_VERSION" ]; then
+    echo "AWS CLI version $AWSCLI_VERSION is already installed. Skipping installation."
+  else
+    echo "AWS CLI version $INSTALLED_VERSION found. Updating to $AWSCLI_VERSION..."
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o "awscliv2.zip"
+    unzip -o awscliv2.zip
+    sudo ./aws/install --bin-dir /usr/bin --install-dir /usr/local/aws-cli --update
+  fi
+else
+  echo "AWS CLI not found. Installing version $AWSCLI_VERSION..."
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o "awscliv2.zip"
+  unzip -o awscliv2.zip
+  sudo ./aws/install --bin-dir /usr/bin --install-dir /usr/local/aws-cli --update
+fi
 
 # secrets in devin.ai env
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Change is limited to startup tooling and only affects how AWS CLI is installed/updated, with minimal impact beyond environment bootstrap.
> 
> **Overview**
> Pins AWS CLI installation in `devin-ai-startup-commands.sh` to version `2.33.19` and makes the install idempotent by detecting an existing `aws` binary and skipping or updating based on the installed version.
> 
> Replaces the previous always-download installer with a versioned ZIP URL and adds clearer logging around whether the script is installing, upgrading, or no-op’ing AWS CLI before proceeding with AWS configuration/codeartifact login.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d53b31980ee6be9444a0c6e90857d338a949cba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->